### PR TITLE
주문 페이지 상품 정보&이미지 연결 완료

### DIFF
--- a/src/main/java/com/grepp/team07/app/controller/web/product/ProductController.java
+++ b/src/main/java/com/grepp/team07/app/controller/web/product/ProductController.java
@@ -1,6 +1,5 @@
 package com.grepp.team07.app.controller.web.product;
 
-import com.grepp.team07.app.model.ordered.dto.OrderedDto;
 import com.grepp.team07.app.model.product.ProductService;
 import com.grepp.team07.app.model.product.dto.ProductDto;
 import com.grepp.team07.infra.exceptions.CommonException;

--- a/src/main/webapp/WEB-INF/view/product.jsp
+++ b/src/main/webapp/WEB-INF/view/product.jsp
@@ -3,11 +3,9 @@
 
 <html lang="ko">
 <head>
-  <!-- Required meta tags -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <!-- Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
   <style>
@@ -109,7 +107,14 @@
         <c:forEach var="product" items="${page.content()}">
           <li class="list-group-item d-flex mt-3">
             <div class="col-2">
-<%--              <img class="img-fluid" src="${product.image}" alt="">--%>
+              <c:if test="${empty product.images}">
+                <img src="#" alt="thumbnail" class="circle">
+              </c:if>
+              <c:if test="${not empty product.images}">
+                <c:forEach items="${product.images}" var="image">
+                  <img src="${image.url}" alt="thumbnail" class="circle">
+                </c:forEach>
+              </c:if>
             </div>
             <div class="col">
               <div class="row text-muted">${product.brand}</div>


### PR DESCRIPTION

## 📌 과제 설명 
![image](https://github.com/user-attachments/assets/d4df7217-8aac-4cc8-beda-1415f761ecc2)


## 👩‍💻 요구 사항과 구현 내용 
주문 화면에서 상품 목록의 이미지가 잘 뜨도록 수정하였습니다.

## ✅ 피드백 반영사항  

## ✅ PR 포인트 & 궁금한 점
