### PR TITLE
Feat.member order

### DIFF
--- a/.idea/webContexts.xml
+++ b/.idea/webContexts.xml
@@ -5,6 +5,7 @@
       <map>
         <entry key="file://$PROJECT_DIR$/src/main/webapp/WEB-INF/view/mypageEdit.jsp" value="file://$PROJECT_DIR$/src/main/webapp/WEB-INF/view" />
         <entry key="file://$PROJECT_DIR$/src/main/webapp/WEB-INF/view/order/order-list.jsp" value="file://$PROJECT_DIR$/src/main/webapp/WEB-INF/view/order" />
+        <entry key="file://$PROJECT_DIR$/src/main/webapp/WEB-INF/view/product/product-list.jsp" value="file://$PROJECT_DIR$/src/main/webapp/WEB-INF/view/product" />
       </map>
     </option>
   </component>

--- a/src/main/java/com/grepp/team07/app/controller/web/order/OrderController.java
+++ b/src/main/java/com/grepp/team07/app/controller/web/order/OrderController.java
@@ -6,8 +6,8 @@ import com.grepp.team07.app.model.ordered.OrderedService;
 import com.grepp.team07.app.model.ordered.dto.OrderedDto;
 import com.grepp.team07.infra.payload.PageParam;
 import com.grepp.team07.infra.response.PageResponse;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -18,6 +18,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -56,5 +57,23 @@ public class OrderController {
         model.addAttribute("page", response);
 
         return "order/order-list";
+    }
+
+    @PostMapping("/create")
+    public String create(
+        @RequestParam String email,
+        @RequestParam String address,
+        @RequestParam String postCode,
+        HttpSession session,
+        Authentication authentication
+    ) {
+        String userId = authentication != null
+            && authentication.isAuthenticated()
+            && !"anonymousUser".equals(authentication.getPrincipal())
+            ? authentication.getName() : null;
+
+        orderedService.create(session, email, address, postCode, userId);
+
+        return "redirect:/";
     }
 }

--- a/src/main/java/com/grepp/team07/app/controller/web/product/ProductController.java
+++ b/src/main/java/com/grepp/team07/app/controller/web/product/ProductController.java
@@ -59,11 +59,15 @@ public class ProductController {
         model.addAttribute("cartItems", cartItems);
 
         Map<Integer, String> productNames = new HashMap<>();
+        Map<Integer, Integer> productPrices = new HashMap<>();
+
         for (CartProductDto i : cartItems) {
             ProductDto dto = productService.findById(i.getProductId());
             productNames.put(i.getProductId(), dto.getName());
+            productPrices.put(i.getProductId(), Integer.parseInt(dto.getPrice()));
         }
         model.addAttribute("productNames", productNames);
+        model.addAttribute("productPrices", productPrices);
 
         Page<ProductDto> page;
         if (item == null || item.isBlank()) {

--- a/src/main/java/com/grepp/team07/app/controller/web/product/ProductController.java
+++ b/src/main/java/com/grepp/team07/app/controller/web/product/ProductController.java
@@ -3,6 +3,8 @@ package com.grepp.team07.app.controller.web.product;
 import com.grepp.team07.app.model.auth.domain.Principal;
 import com.grepp.team07.app.model.cart.CartService;
 import com.grepp.team07.app.model.cart.dto.CartProductDto;
+import com.grepp.team07.app.model.member.dto.Member;
+import com.grepp.team07.app.model.member.repository.MemberRepository;
 import com.grepp.team07.app.model.product.ProductService;
 import com.grepp.team07.app.model.product.dto.ProductDto;
 import com.grepp.team07.infra.exceptions.CommonException;
@@ -37,6 +39,7 @@ public class ProductController {
 
     private final ProductService productService;
     private final CartService cartService;
+    private final MemberRepository memberRepository;
 
     @GetMapping("")
     public String productList(@Valid PageParam param,
@@ -76,6 +79,15 @@ public class ProductController {
 
         PageResponse<ProductDto> response = new PageResponse<>("/product", page, 3);
         model.addAttribute("page", response);
+
+        if (userId != null) {
+            Member member = memberRepository.selectByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 회원입니다: " + userId));
+
+            model.addAttribute("loginEmail", member.getEmail());
+            model.addAttribute("loginAddress", member.getAddress());
+            model.addAttribute("loginPostCode", member.getPostCode());
+        }
 
         return "product/product-list";
     }

--- a/src/main/java/com/grepp/team07/app/model/delivery/DeliveryRepository.java
+++ b/src/main/java/com/grepp/team07/app/model/delivery/DeliveryRepository.java
@@ -18,4 +18,6 @@ public interface DeliveryRepository {
     void updateDeliveredAt(@Param("deliveryId")Integer deliveryId, @Param("deliveredAt")LocalDateTime deliveredAt);
 
     void updateStatus(@Param("deliveryId")Integer deliveryId, @Param("status")DeliveryState status);
+
+    void insertDelivery(@Param("orderId") Integer orderId, @Param("customerId") Integer customerId, @Param("status") DeliveryState status);
 }

--- a/src/main/java/com/grepp/team07/app/model/ordered/OrderedRepository.java
+++ b/src/main/java/com/grepp/team07/app/model/ordered/OrderedRepository.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
+import java.util.Map;
 
 @Mapper
 public interface OrderedRepository {
@@ -20,4 +21,32 @@ public interface OrderedRepository {
 
     List<OrderedDto> searchByMemberEmail(@Param("limit") int limit, @Param("offset") int offset, String email);
     int countMemberEmailOrders(String email);
+
+    // 회원 주문 생성
+    void insertMemberOrder(@Param("email") String email,
+                           @Param("address") String address,
+                           @Param("postCode") String postCode,
+                           @Param("userId") String userId);
+
+    // 비회원 주문 생성
+    void insertGuestOrder(@Param("email") String email,
+                          @Param("address") String address,
+                          @Param("postCode") String postCode);
+
+    // 생성된 orderId 가져오기
+    Integer findLastOrderId();
+
+    // 상품 가격 가져오기
+    Integer findProductPrice(@Param("productId") Integer productId);
+
+    // 주문 상품 추가
+    void insertOrderProducts(@Param("orderId") Integer orderId,
+                             @Param("productId") Integer productId,
+                             @Param("count") Integer count);
+
+    // 총 가격 업데이트
+    void updateOrderTotalPrice(@Param("orderId") Integer orderId,
+                               @Param("totalPrice") Integer totalPrice);
+
+    List<Map<String, Object>> findCartProductByUserId(@Param("userId") String userId);
 }

--- a/src/main/java/com/grepp/team07/app/model/ordered/OrderedRepository.java
+++ b/src/main/java/com/grepp/team07/app/model/ordered/OrderedRepository.java
@@ -49,4 +49,6 @@ public interface OrderedRepository {
                                @Param("totalPrice") Integer totalPrice);
 
     List<Map<String, Object>> findCartProductByUserId(@Param("userId") String userId);
+
+    Integer findCustomerIdByUserId(@Param("userId") String userId);
 }

--- a/src/main/java/com/grepp/team07/app/model/ordered/OrderedService.java
+++ b/src/main/java/com/grepp/team07/app/model/ordered/OrderedService.java
@@ -1,6 +1,8 @@
 package com.grepp.team07.app.model.ordered;
 
 import com.grepp.team07.app.model.cart.CartRepository;
+import com.grepp.team07.app.model.delivery.DeliveryRepository;
+import com.grepp.team07.app.model.delivery.code.DeliveryState;
 import com.grepp.team07.app.model.ordered.dto.OrderedDto;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ public class OrderedService {
 
     private final OrderedRepository orderedRepository;
     private final CartRepository cartRepository;
+    private final DeliveryRepository deliveryRepository;
 
     public List<OrderedDto> findAll() {
         return orderedRepository.selectAll();
@@ -61,6 +64,10 @@ public class OrderedService {
             // 회원
             orderedRepository.insertMemberOrder(email, address, postCode, userId);
             Integer orderId = orderedRepository.findLastOrderId();
+
+            Integer customerId = orderedRepository.findCustomerIdByUserId(userId);
+            deliveryRepository.insertDelivery(orderId, customerId, DeliveryState.READY);
+
             List<Map<String, Object>> cartProducts = orderedRepository.findCartProductByUserId(userId);
 
             for (Map<String, Object> item : cartProducts) {
@@ -80,6 +87,8 @@ public class OrderedService {
             orderedRepository.insertGuestOrder(email, address, postCode);
 
             Integer orderId = orderedRepository.findLastOrderId();
+
+            deliveryRepository.insertDelivery(orderId, null, DeliveryState.READY);
 
             int totalPrice = 0;
             for (Map.Entry<Integer, Integer> entry : guestCart.entrySet()) {

--- a/src/main/java/com/grepp/team07/app/model/ordered/OrderedService.java
+++ b/src/main/java/com/grepp/team07/app/model/ordered/OrderedService.java
@@ -1,6 +1,8 @@
 package com.grepp.team07.app.model.ordered;
 
+import com.grepp.team07.app.model.cart.CartRepository;
 import com.grepp.team07.app.model.ordered.dto.OrderedDto;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -9,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +19,7 @@ import java.util.List;
 public class OrderedService {
 
     private final OrderedRepository orderedRepository;
+    private final CartRepository cartRepository;
 
     public List<OrderedDto> findAll() {
         return orderedRepository.selectAll();
@@ -46,5 +50,49 @@ public class OrderedService {
         int total = orderedRepository.countMemberEmailOrders(email);
 
         return new PageImpl<>(result, pageable, total);
+    }
+
+    public void create(HttpSession session, String email, String address, String postCode, String userId) {
+        if (email == null || email.isBlank() || address == null || address.isBlank() || postCode == null || postCode.isBlank()) {
+            throw new IllegalArgumentException("이메일, 주소, 우편번호를 모두 입력해야 합니다.");
+        }
+
+        if (userId != null) {
+            // 회원
+            orderedRepository.insertMemberOrder(email, address, postCode, userId);
+            Integer orderId = orderedRepository.findLastOrderId();
+            List<Map<String, Object>> cartProducts = orderedRepository.findCartProductByUserId(userId);
+
+            for (Map<String, Object> item : cartProducts) {
+                Integer productId = (Integer) item.get("product_id");
+                Integer count = (Integer) item.get("count");
+                orderedRepository.insertOrderProducts(orderId, productId, count);
+            }
+
+            cartRepository.deactivateCart(userId);
+        } else {
+            // 비회원
+            Map<Integer, Integer> guestCart = (Map<Integer, Integer>) session.getAttribute("guestCart");
+            if (guestCart == null || guestCart.isEmpty()) {
+                throw new IllegalArgumentException("장바구니가 비어있습니다.");
+            }
+
+            orderedRepository.insertGuestOrder(email, address, postCode);
+
+            Integer orderId = orderedRepository.findLastOrderId();
+
+            int totalPrice = 0;
+            for (Map.Entry<Integer, Integer> entry : guestCart.entrySet()) {
+                Integer productId = entry.getKey();
+                Integer count = entry.getValue();
+                Integer price = orderedRepository.findProductPrice(productId);
+                totalPrice += price * count;
+                orderedRepository.insertOrderProducts(orderId, productId, count);
+            }
+
+            orderedRepository.updateOrderTotalPrice(orderId, totalPrice);
+
+            session.removeAttribute("guestCart");
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 upload.path=
 spring.datasource.url=jdbc:mysql://localhost:3306/team07?useUnicode=true&characterEncoding=utf8
 spring.datasource.username=bm
-spring.datasource.password=1234
+spring.datasource.password=123qwe!@#
 spring.datasource.driver=com.mysql.cj.jdbc.Driver
 spring.datasource.hikari.maximum-pool-size=1
 remember-me.key=123qwe!@#

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 upload.path=
 spring.datasource.url=jdbc:mysql://localhost:3306/team07?useUnicode=true&characterEncoding=utf8
 spring.datasource.username=bm
-spring.datasource.password=123qwe!@#
+spring.datasource.password=1234
 spring.datasource.driver=com.mysql.cj.jdbc.Driver
 spring.datasource.hikari.maximum-pool-size=1
 remember-me.key=123qwe!@#

--- a/src/main/resources/init/schema.sql
+++ b/src/main/resources/init/schema.sql
@@ -77,7 +77,7 @@ CREATE TABLE IF NOT EXISTS `DELIVERY`
 (
     `delivery_id`  INT                                    NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '배송번호',
     `order_id`     INT                                    NOT NULL COMMENT '주문번호',
-    `customer_id`  INT                                    NOT NULL COMMENT '회원번호',
+    `customer_id`  INT                                    NULL COMMENT '회원번호',
     `status`       ENUM ('READY', 'SHIPPED', 'DELIVERED') NOT NULL COMMENT '주문상태',
     `delivered_at` TIMESTAMP                              NULL DEFAULT now() COMMENT '배송일시',
     FOREIGN KEY (`order_id`) REFERENCES ORDERED (`order_id`),

--- a/src/main/resources/mybatis/mappers/delivery/deliveryMapper.xml
+++ b/src/main/resources/mybatis/mappers/delivery/deliveryMapper.xml
@@ -26,4 +26,9 @@
         update delivery set delivered_at = #{deliveredAt}
         where delivery_id = #{deliveryId}
     </update>
+
+    <insert id="insertDelivery">
+        insert into delivery (order_id, customer_id, status)
+        values (#{orderId}, #{customerId}, #{status})
+    </insert>
 </mapper>

--- a/src/main/resources/mybatis/mappers/ordered/orderedMapper.xml
+++ b/src/main/resources/mybatis/mappers/ordered/orderedMapper.xml
@@ -74,4 +74,61 @@
         where email = #{email} and is_customer is true
     </select>
 
+    <insert id="insertMemberOrder">
+        insert into ordered (cart_id, email, is_customer, address, post_code, total_price)
+        values (
+        (select c.cart_id
+        from cart c
+        join customer cu on c.customer_id = cu.id
+        where cu.user_id = #{userId}
+        and c.is_activated = true),
+        #{email},
+        true,
+        #{address},
+        #{postCode},
+        (select sum(p.price * cp.count)
+        from cart_product cp
+        join cart c on cp.cart_id = c.cart_id
+        join product p on cp.product_id = p.product_id
+        join customer cu on c.customer_id = cu.id
+        where cu.user_id = #{userId}
+        and c.is_activated = true)
+        )
+    </insert>
+
+    <insert id="insertGuestOrder">
+        insert into ordered (email, is_customer, address, post_code, total_price)
+        values (#{email}, false, #{address}, #{postCode}, 0)
+    </insert>
+
+    <select id="findLastOrderId" resultType="int">
+        select last_insert_id()
+    </select>
+
+    <select id="findProductPrice" parameterType="int" resultType="int">
+        select price
+        from product
+        where product_id = #{productId}
+    </select>
+
+    <insert id="insertOrderProducts">
+        insert into order_product (order_id, product_id, count)
+        values (#{orderId}, #{productId}, #{count})
+    </insert>
+
+    <update id="updateOrderTotalPrice">
+        update ordered
+        set total_price = #{totalPrice}
+        where order_id = #{orderId}
+    </update>
+
+    <select id="findCartProductByUserId" resultType="map">
+        select cp.product_id, cp.count
+        from cart_product cp
+        join cart c on cp.cart_id = c.cart_id
+        join customer cu on c.customer_id = cu.id
+        where cu.user_id = #{userId}
+        and c.is_activated = true
+    </select>
+
 </mapper>

--- a/src/main/resources/mybatis/mappers/ordered/orderedMapper.xml
+++ b/src/main/resources/mybatis/mappers/ordered/orderedMapper.xml
@@ -131,4 +131,10 @@
         and c.is_activated = true
     </select>
 
+    <select id="findCustomerIdByUserId" resultType="int">
+        select id
+        from customer
+        where user_id = #{userId}
+    </select>
+
 </mapper>

--- a/src/main/webapp/WEB-INF/view/include/cart.jsp
+++ b/src/main/webapp/WEB-INF/view/include/cart.jsp
@@ -1,0 +1,73 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+
+<div class="col-md-4 summary p-4">
+    <div>
+        <h5 class="m-0 p-0"><b>Cart</b></h5>
+    </div>
+    <hr>
+    <c:forEach var="item" items="${cartItems}">
+        <div class="row align-items-center mb-2">
+            <div class="col-8">
+                <h6 class="p-0 m-0">
+                        ${productNames[item.productId]}
+                </h6>
+            </div>
+            <div class="col-4 d-flex align-items-center justify-content-end gap-1">
+                <form action="${pageContext.request.contextPath}/cart/decrease" method="post" style="display:inline;">
+                    <input type="hidden" name="productId" value="${item.productId}" />
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
+                    <button type="submit" class="btn btn-sm btn-outline-dark" style="border-color: #ccc; margin-top: 4px;">-</button>
+                </form>
+                <span class="badge bg-dark">${item.count}개</span>
+                <form action="${pageContext.request.contextPath}/cart/increase" method="post" style="display:inline;">
+                    <input type="hidden" name="productId" value="${item.productId}" />
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
+                    <button type="submit" class="btn btn-sm btn-outline-dark" style="border-color: #ccc; margin-top: 4px;">+</button>
+                </form>
+                <form action="${pageContext.request.contextPath}/cart/remove" method="post" style="display:inline;">
+                    <input type="hidden" name="productId" value="${item.productId}" />
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
+                    <button type="submit" class="btn btn-sm btn-outline-dark px-2"
+                            style="min-width: 30px; white-space: nowrap; border-color: red; color: red; margin-top: 4px;">
+                        <i class="bi bi-trash3"></i>
+                    </button>
+                </form>
+            </div>
+        </div>
+    </c:forEach>
+
+    <form id="orderForm" action="${pageContext.request.contextPath}/order/create" method="post">
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
+        <div class="mb-3">
+            <label for="email" class="form-label">이메일</label>
+            <input type="email" class="form-control mb-1" id="email" name="email"
+                   value="${loginEmail}" ${not empty loginEmail ? 'readonly' : ''} required>
+        </div>
+        <div class="mb-3">
+            <label for="address" class="form-label">주소</label>
+            <input type="text" class="form-control mb-1" id="address" name="address"
+                   value="${loginAddress}" required>
+        </div>
+        <div class="mb-3">
+            <label for="postcode" class="form-label">우편번호</label>
+            <input type="text" class="form-control" id="postcode" name="postCode"
+                   value="${loginPostCode}" required>
+        </div>
+        <div>당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</div>
+
+        <div class="row pt-2 pb-2 border-top">
+            <h5 class="col">총금액</h5>
+            <h5 class="col text-end">
+                <c:set var="totalPrice" value="0" />
+                <c:forEach var="item" items="${cartItems}">
+                    <c:set var="itemPrice" value="${productPrices[item.productId]}" />
+                    <c:set var="subtotal" value="${item.count * itemPrice}" />
+                    <c:set var="totalPrice" value="${totalPrice + subtotal}" />
+                </c:forEach>
+                <fmt:formatNumber value="${totalPrice}" pattern="#,###"/>원
+            </h5>
+        </div>
+
+        <button type="submit" class="btn btn-dark col-12 mt-2">결제하기</button>
+    </form>
+</div>

--- a/src/main/webapp/WEB-INF/view/member/mypage.jsp
+++ b/src/main/webapp/WEB-INF/view/member/mypage.jsp
@@ -78,49 +78,16 @@
                 <a href="edit"><div class="edit-button">수정</div></a>
             </div>
 
-            <div class="d-flex mb-2 w-100"><div class="info-label">id</div><div><c:out value="${info.get().userId}"/></div></div>
-            <div class="d-flex mb-2 w-100"><div class="info-label">email</div><div><c:out value="${info.get().email}"/></div></div>
-            <div class="d-flex mb-2 w-100"><div class="info-label">주소</div><div><c:out value="${info.get().address}"/></div></div>
-            <div class="d-flex mb-2 w-100"><div class="info-label">우편번호</div><div><c:out value="${info.get().postCode}"/></div></div>
+            <div class="d-flex mb-2 w-100"><div class="info-label">id</div><div><c:out value="${info.userId}"/></div></div>
+            <div class="d-flex mb-2 w-100"><div class="info-label">email</div><div><c:out value="${info.email}"/></div></div>
+            <div class="d-flex mb-2 w-100"><div class="info-label">주소</div><div><c:out value="${info.address}"/></div></div>
+            <div class="d-flex mb-2 w-100"><div class="info-label">우편번호</div><div><c:out value="${info.postCode}"/></div></div>
 
             <a href="/order/list" class="btn mb-2 mt-4">주문 목록 더보기</a>
         </div>
 
-        <div class="col-md-4 summary p-4">
-            <div>
-                <h5 class="m-0 p-0"><b>Summary</b></h5>
-            </div>
-            <hr>
-            <div class="row">
-                <h6 class="p-0">Columbia Nariñó <span class="badge bg-dark">2개</span></h6>
-            </div>
-            <div class="row">
-                <h6 class="p-0">Brazil Serra Do Caparaó <span class="badge bg-dark">2개</span></h6>
-            </div>
-            <div class="row">
-                <h6 class="p-0">Columbia Nariñó <span class="badge bg-dark">2개</span></h6>
-            </div>
-            <form>
-                <div class="mb-3">
-                    <label for="email" class="form-label">이메일</label>
-                    <input type="email" class="form-control mb-1" id="email">
-                </div>
-                <div class="mb-3">
-                    <label for="address" class="form-label">주소</label>
-                    <input type="text" class="form-control mb-1" id="address">
-                </div>
-                <div class="mb-3">
-                    <label for="postcode" class="form-label">우편번호</label>
-                    <input type="text" class="form-control" id="postcode">
-                </div>
-                <div>당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</div>
-            </form>
-            <div class="row pt-2 pb-2 border-top">
-                <h5 class="col">총금액</h5>
-                <h5 class="col text-end">15000원</h5>
-            </div>
-            <button class="btn btn-dark col-12">결제하기</button>
-        </div>
+        <%@ include file="/WEB-INF/view/include/cart.jsp" %>
+
     </div>
 </div>
 </body>

--- a/src/main/webapp/WEB-INF/view/product/product-list.jsp
+++ b/src/main/webapp/WEB-INF/view/product/product-list.jsp
@@ -151,96 +151,23 @@
                 <i class="bi bi-chevron-double-left"></i>
               </a>
             </li>
-
             <c:forEach var="i" begin="${page.startNumber()}" end="${page.endNumber()}">
               <li class="page-item <c:if test='${page.currentNumber() == i}'>active</c:if>'">
                 <a class="page-link" href="${page.url()}?page=${i}">${i}</a>
               </li>
             </c:forEach>
-
             <li class="page-item <c:if test='${page.currentNumber() == page.endNumber()}'>disabled</c:if>'">
               <a class="page-link" href="${page.url()}?page=${page.nextPage()}">
                 <i class="bi bi-chevron-double-right"></i>
               </a>
             </li>
-
           </ul>
         </nav>
       </div>
-
     </div>
-    <div class="col-md-4 summary p-4">
-      <div>
-        <h5 class="m-0 p-0"><b>Cart</b></h5>
-      </div>
-      <hr>
-      <c:forEach var="item" items="${cartItems}">
-        <div class="row align-items-center mb-2">
-          <div class="col-8">
-            <h6 class="p-0 m-0">
-                ${productNames[item.productId]}
-            </h6>
-          </div>
-          <div class="col-4 d-flex align-items-center justify-content-end gap-1">
-            <form action="${pageContext.request.contextPath}/cart/decrease" method="post" style="display:inline;">
-              <input type="hidden" name="productId" value="${item.productId}" />
-              <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
-              <button type="submit" class="btn btn-sm btn-outline-dark" style="border-color: #ccc; margin-top: 4px;">-</button>
-            </form>
-            <span class="badge bg-dark">${item.count}개</span>
-            <form action="${pageContext.request.contextPath}/cart/increase" method="post" style="display:inline;">
-              <input type="hidden" name="productId" value="${item.productId}" />
-              <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
-              <button type="submit" class="btn btn-sm btn-outline-dark" style="border-color: #ccc; margin-top: 4px;">+</button>
-            </form>
-            <form action="${pageContext.request.contextPath}/cart/remove" method="post" style="display:inline;">
-              <input type="hidden" name="productId" value="${item.productId}" />
-              <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
-              <button type="submit" class="btn btn-sm btn-outline-dark px-2"
-                      style="min-width: 30px; white-space: nowrap; border-color: red; color: red; margin-top: 4px;">
-                <i class="bi bi-trash3"></i>
-              </button>
-            </form>
-          </div>
-        </div>
-      </c:forEach>
 
-      <form id="orderForm" action="${pageContext.request.contextPath}/order/create" method="post">
-        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
+    <%@ include file="/WEB-INF/view/include/cart.jsp" %>
 
-        <div class="mb-3">
-          <label for="email" class="form-label">이메일</label>
-          <input type="email" class="form-control mb-1" id="email" name="email"
-                 value="${loginEmail}" ${not empty loginEmail ? 'readonly' : ''} required>
-        </div>
-        <div class="mb-3">
-          <label for="address" class="form-label">주소</label>
-          <input type="text" class="form-control mb-1" id="address" name="address"
-                 value="${loginAddress}" required>
-        </div>
-        <div class="mb-3">
-          <label for="postcode" class="form-label">우편번호</label>
-          <input type="text" class="form-control" id="postcode" name="postCode"
-                 value="${loginPostCode}" required>
-        </div>
-        <div>당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</div>
-
-        <div class="row pt-2 pb-2 border-top">
-          <h5 class="col">총금액</h5>
-          <h5 class="col text-end">
-            <c:set var="totalPrice" value="0" />
-            <c:forEach var="item" items="${cartItems}">
-              <c:set var="itemPrice" value="${productPrices[item.productId]}" />
-              <c:set var="subtotal" value="${item.count * itemPrice}" />
-              <c:set var="totalPrice" value="${totalPrice + subtotal}" />
-            </c:forEach>
-            <fmt:formatNumber value="${totalPrice}" pattern="#,###"/>원
-          </h5>
-        </div>
-
-        <button type="submit" class="btn btn-dark col-12 mt-2">결제하기</button>
-      </form>
-    </div>
   </div>
 </div>
 </body>

--- a/src/main/webapp/WEB-INF/view/product/product-list.jsp
+++ b/src/main/webapp/WEB-INF/view/product/product-list.jsp
@@ -205,26 +205,41 @@
         </div>
       </c:forEach>
 
-      <form>
+      <form id="orderForm" action="${pageContext.request.contextPath}/order/create" method="post">
+        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
+
         <div class="mb-3">
           <label for="email" class="form-label">이메일</label>
-          <input type="email" class="form-control mb-1" id="email">
+          <input type="email" class="form-control mb-1" id="email" name="email"
+                 value="${loginEmail}" ${not empty loginEmail ? 'readonly' : ''} required>
         </div>
         <div class="mb-3">
           <label for="address" class="form-label">주소</label>
-          <input type="text" class="form-control mb-1" id="address">
+          <input type="text" class="form-control mb-1" id="address" name="address"
+                 value="${loginAddress}" required>
         </div>
         <div class="mb-3">
           <label for="postcode" class="form-label">우편번호</label>
-          <input type="text" class="form-control" id="postcode">
+          <input type="text" class="form-control" id="postcode" name="postCode"
+                 value="${loginPostCode}" required>
         </div>
         <div>당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</div>
+
+        <div class="row pt-2 pb-2 border-top">
+          <h5 class="col">총금액</h5>
+          <h5 class="col text-end">
+            <c:set var="totalPrice" value="0" />
+            <c:forEach var="item" items="${cartItems}">
+              <c:set var="itemPrice" value="${productPrices[item.productId]}" />
+              <c:set var="subtotal" value="${item.count * itemPrice}" />
+              <c:set var="totalPrice" value="${totalPrice + subtotal}" />
+            </c:forEach>
+            <fmt:formatNumber value="${totalPrice}" pattern="#,###"/>원
+          </h5>
+        </div>
+
+        <button type="submit" class="btn btn-dark col-12 mt-2">결제하기</button>
       </form>
-      <div class="row pt-2 pb-2 border-top">
-        <h5 class="col">총금액</h5>
-        <h5 class="col text-end">15000원</h5>
-      </div>
-      <button class="btn btn-dark col-12">결제하기</button>
     </div>
   </div>
 </div>

--- a/src/test/java/com/grepp/team07/app/model/ordered/OrderedServiceTest.java
+++ b/src/test/java/com/grepp/team07/app/model/ordered/OrderedServiceTest.java
@@ -5,10 +5,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations={
@@ -26,4 +31,36 @@ class OrderedServiceTest {
         orders.forEach(System.out::println);
     }
 
+    @Test
+    public void createGuestOrderTest() {
+        // 비회원 주문 테스트
+        MockHttpSession session = new MockHttpSession();
+        Map<Integer, Integer> guestCart = new HashMap<>();
+        guestCart.put(1, 2);
+        guestCart.put(2, 1);
+        session.setAttribute("guestCart", guestCart);
+
+        String email = "guest@example.com";
+        String address = "비회원주소";
+        String postCode = "12345";
+
+        assertDoesNotThrow(() -> orderedService.create(session, email, address, postCode, null));
+
+        log.info("비회원 주문 생성 완료");
+    }
+
+    @Test
+    public void createMemberOrderTest() {
+        // 회원 주문 테스트
+        MockHttpSession session = new MockHttpSession();
+
+        String email = "member@example.com";
+        String address = "회원주소";
+        String postCode = "67890";
+        String userId = "user01";
+
+        assertDoesNotThrow(() -> orderedService.create(session, email, address, postCode, userId));
+
+        log.info("회원 주문 생성 완료");
+    }
 }


### PR DESCRIPTION
## 📌 과제 설명
회원과 비회원 상품 주문 기능
## 👩‍💻 요구 사항과 구현 내용
회원, 비회원 상품 주문 로직을 구현했습니다.
delivery 테이블에서 customer_id가 not null로 되어있어서 비회원일때 저장이 되지않아서 null로 변경했습니다.
delivery 로직에 주문 관련 로직을 추가하였습니다.
cart 폼을 include 폴더에 생성하여 분리하였습니다.
## ✅ PR 포인트 & 궁금한 점
- 회원 주문 (이메일 변경 X, 주소와 우편번호는 변경 가능)
- 비회원 주문 (이메일, 주소, 우편번호 모두 입력)

https://github.com/user-attachments/assets/d8218d8e-ae01-491c-9693-ed6d7a3f1a72


- 입력란 공백 시 주문 X

https://github.com/user-attachments/assets/4d00676f-eb08-4fe0-99cb-0fe34c0263ea